### PR TITLE
bug about Map.keySet()

### DIFF
--- a/src/main/java/com/github/hcsp/collection/CharCount.java
+++ b/src/main/java/com/github/hcsp/collection/CharCount.java
@@ -3,6 +3,7 @@ package com.github.hcsp.collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 public class CharCount {
     /**
@@ -43,7 +44,7 @@ public class CharCount {
     // 我和另外一个CharCount有多少个公共字符？ 例如，aabbcc和abcdef有3个公共字符: a/b/c，因此返回3
     public int howManyCharsInCommon(CharCount anotherCharCount) {
         Set<Character> myChars = chars();
-        Set<Character> theirChars = anotherCharCount.chars();
+        Set<Character> theirChars = new HashSet<>(anotherCharCount.chars());
 
         theirChars.retainAll(myChars);
         return theirChars.size();


### PR DESCRIPTION
HashMap.keySet() returns a view of the keys contained in this map.