### PR TITLE
修复HashSet数据丢失问题

### DIFF
--- a/src/main/java/com/github/hcsp/collection/CharCount.java
+++ b/src/main/java/com/github/hcsp/collection/CharCount.java
@@ -1,6 +1,7 @@
 package com.github.hcsp.collection;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,10 +43,11 @@ public class CharCount {
 
     // 我和另外一个CharCount有多少个公共字符？ 例如，aabbcc和abcdef有3个公共字符: a/b/c，因此返回3
     public int howManyCharsInCommon(CharCount anotherCharCount) {
-        Set<Character> myChars = chars();
-        Set<Character> theirChars = anotherCharCount.chars();
+        Set<Character> myChars = new HashSet<>(chars());
+        Set<Character> theirChars = new HashSet<>(anotherCharCount.chars());
 
         theirChars.retainAll(myChars);
         return theirChars.size();
     }
+
 }


### PR DESCRIPTION
retainAll会修改原先的数据，new HashSet()做了保护性的拷贝，避免修改原先的数据

