### PR TITLE
修修复了HashMap丢失数据的问题

### DIFF
--- a/src/main/java/com/github/hcsp/collection/CharCount.java
+++ b/src/main/java/com/github/hcsp/collection/CharCount.java
@@ -1,6 +1,7 @@
 package com.github.hcsp.collection;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,8 +45,8 @@ public class CharCount {
     public int howManyCharsInCommon(CharCount anotherCharCount) {
         Set<Character> myChars = chars();
         Set<Character> theirChars = anotherCharCount.chars();
-
-        theirChars.retainAll(myChars);
-        return theirChars.size();
+        Set<Character>  temp = new HashSet<>(theirChars);
+        temp.retainAll(myChars);
+        return temp.size();
     }
 }


### PR DESCRIPTION
原因是在howManyCharsInCommon方法中运用了retainAll方法改变了theirChars的容量。

